### PR TITLE
maybe it should be $par

### DIFF
--- a/plugins/function.t.php
+++ b/plugins/function.t.php
@@ -24,5 +24,5 @@ function smarty_function_t($params, &$smarty) {
     $language = !empty($params['lang']) ? $params['lang'] : null;
     $par = !empty($params['params']) ? $params['params'] : array();
 
-    return Yii::t($category, $text, $params, $source, $language);
+    return Yii::t($category, $text, $par, $source, $language);
 }


### PR DESCRIPTION
if you pass $param to Yii::t(), word 'cat' and 'text' would change in message, for example:
Notification would be changed to 'Notifxxxion';
