### PR TITLE
Fix for link function creating incorrectly nested URL parameters (#24)

### DIFF
--- a/plugins/function.link.php
+++ b/plugins/function.link.php
@@ -28,8 +28,8 @@ function smarty_function_link($params, &$smarty){
         if(!isset($parts['host']) && $parts['path'][1]!='/'){
             $par = array();
             parse_str($parts['query'], $par);
-            $url = array(
-                $parts['path'],
+            $url = array_merge(
+                array($parts['path']),
                 $par
             );
         }


### PR DESCRIPTION
This is a small fix for issue #24
(https://github.com/yiiext/smarty-renderer/issues/24).

> The current link function is creating URLs with parameters incorrectly
> nested. This leads to URLs that look like:
> `controller/action/0%5Bparam%5D/value` when encoded, and
> `registration/controller/action/0[param]/value` when decoded.
